### PR TITLE
feat: add support for Claude session usage tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Tokenuze
 
-Tokenuze is a Zig CLI that summarizes OpenAI Codex and Gemini session usage. It scans `~/.codex/sessions` and `~/.gemini/tmp`, aggregates token counts per day and per model, and reports pricing using either the live LiteLLM pricing manifest or local fallbacks. Output is emitted as compact JSON, making it easy to feed into dashboards or further scripts.
+Tokenuze is a Zig CLI that summarizes OpenAI Codex, Gemini, and Claude session usage. It scans `~/.codex/sessions`, `~/.gemini/tmp`, and `~/.claude/projects`, aggregates token counts per day and per model, and reports pricing using either the live LiteLLM pricing manifest or local fallbacks. Output is emitted as compact JSON, making it easy to feed into dashboards or further scripts.
 
 ## Requirements
 - Zig 0.12.0 or newer (stdlib is expected at `/usr/lib/zig/lib`)
 - Access to Codex session logs at `~/.codex/sessions`
 - Optional: access to Gemini session logs at `~/.gemini/tmp`
+- Optional: access to Claude session logs at `~/.claude/projects`
 - Optional: network access to fetch remote pricing
 
 ## Quick Start
@@ -20,7 +21,7 @@ zig build --release=fast run -- --since 20250101  # faster benchmarking runs
 - `--since YYYYMMDD` limits processing to events on/after the specified local date.
 - `--until YYYYMMDD` caps the range; must be >= `--since` when both are present.
 - `--pretty` enables indented JSON output (handy when reading the payload manually).
-- `--model <codex|gemini>` restricts processing to the specified provider; repeat the flag to include multiple (defaults to both).
+- `--model <codex|gemini|claude>` restricts processing to the specified provider; repeat the flag to include multiple (defaults to all providers).
 - `--machine-id` prints the cached/generated machine identifier and exits (no summaries).
 
 ## What It Produces

--- a/src/providers/claude.zig
+++ b/src/providers/claude.zig
@@ -1,0 +1,12 @@
+const SessionProvider = @import("session_provider.zig");
+
+const Provider = SessionProvider.Provider(.{
+    .name = "claude",
+    .sessions_dir_suffix = "/.claude/projects",
+    .legacy_fallback_model = null,
+    .fallback_pricing = &.{},
+    .session_file_ext = ".jsonl",
+    .strategy = .claude,
+});
+
+pub const collect = Provider.collect;

--- a/src/providers/codex.zig
+++ b/src/providers/codex.zig
@@ -1,8 +1,18 @@
 const SessionProvider = @import("session_provider.zig");
 
 const fallback_pricing = [_]SessionProvider.FallbackPricingEntry{
-    .{ .name = "gpt-5", .pricing = .{ .input_cost_per_m = 1.25, .cached_input_cost_per_m = 0.125, .output_cost_per_m = 10.0 } },
-    .{ .name = "gpt-5-codex", .pricing = .{ .input_cost_per_m = 1.25, .cached_input_cost_per_m = 0.125, .output_cost_per_m = 10.0 } },
+    .{ .name = "gpt-5", .pricing = .{
+        .input_cost_per_m = 1.25,
+        .cache_creation_cost_per_m = 1.25,
+        .cached_input_cost_per_m = 0.125,
+        .output_cost_per_m = 10.0,
+    } },
+    .{ .name = "gpt-5-codex", .pricing = .{
+        .input_cost_per_m = 1.25,
+        .cache_creation_cost_per_m = 1.25,
+        .cached_input_cost_per_m = 0.125,
+        .output_cost_per_m = 10.0,
+    } },
 };
 
 const Provider = SessionProvider.Provider(.{

--- a/src/providers/gemini.zig
+++ b/src/providers/gemini.zig
@@ -1,8 +1,18 @@
 const SessionProvider = @import("session_provider.zig");
 
 const fallback_pricing = [_]SessionProvider.FallbackPricingEntry{
-    .{ .name = "gemini-1.5-pro", .pricing = .{ .input_cost_per_m = 3.50, .cached_input_cost_per_m = 3.50, .output_cost_per_m = 10.50 } },
-    .{ .name = "gemini-1.5-flash", .pricing = .{ .input_cost_per_m = 0.35, .cached_input_cost_per_m = 0.35, .output_cost_per_m = 1.05 } },
+    .{ .name = "gemini-1.5-pro", .pricing = .{
+        .input_cost_per_m = 3.50,
+        .cache_creation_cost_per_m = 3.50,
+        .cached_input_cost_per_m = 3.50,
+        .output_cost_per_m = 10.50,
+    } },
+    .{ .name = "gemini-1.5-flash", .pricing = .{
+        .input_cost_per_m = 0.35,
+        .cache_creation_cost_per_m = 0.35,
+        .cached_input_cost_per_m = 0.35,
+        .output_cost_per_m = 1.05,
+    } },
 };
 
 const Provider = SessionProvider.Provider(.{

--- a/src/providers/session_provider.zig
+++ b/src/providers/session_provider.zig
@@ -10,6 +10,7 @@ pub const FallbackPricingEntry = struct {
 pub const ParseStrategy = enum {
     codex,
     gemini,
+    claude,
 };
 
 pub const ProviderConfig = struct {
@@ -256,6 +257,7 @@ pub fn Provider(comptime cfg: ProviderConfig) type {
             switch (STRATEGY) {
                 .codex => try parseCodexSessionFile(allocator, arena, session_id, file_path, events),
                 .gemini => try parseGeminiSessionFile(allocator, arena, session_id, file_path, events),
+                .claude => try parseClaudeSessionFile(allocator, arena, session_id, file_path, events),
             }
         }
 
@@ -473,6 +475,279 @@ pub fn Provider(comptime cfg: ProviderConfig) type {
                     0,
                 .number_string => |slice| Model.parseTokenNumber(slice),
                 else => 0,
+            };
+        }
+
+        fn parseClaudeSessionFile(
+            allocator: std.mem.Allocator,
+            arena: std.mem.Allocator,
+            session_id: []const u8,
+            file_path: []const u8,
+            events: *std.ArrayListUnmanaged(Model.TokenUsageEvent),
+        ) !void {
+            const max_session_size: usize = 128 * 1024 * 1024;
+            const file = std.fs.cwd().openFile(file_path, .{}) catch |err| {
+                logSessionWarning(file_path, "unable to open claude session file", err);
+                return;
+            };
+            defer file.close();
+
+            var io_single = std.Io.Threaded.init_single_threaded;
+            defer io_single.deinit();
+            const io = io_single.io();
+
+            var reader_buffer: [64 * 1024]u8 = undefined;
+            var file_reader = file.readerStreaming(io, reader_buffer[0..]);
+            var reader = &file_reader.interface;
+
+            var partial_line = std.ArrayListUnmanaged(u8){};
+            defer partial_line.deinit(allocator);
+
+            var session_label = session_id;
+            var session_label_overridden = false;
+            var current_model: ?[]const u8 = null;
+            var current_model_is_fallback = false;
+            var streamed_total: usize = 0;
+            var line_index: usize = 0;
+            var seen_messages = std.AutoHashMap(u64, void).init(allocator);
+            defer seen_messages.deinit();
+
+            while (true) {
+                partial_line.clearRetainingCapacity();
+                var writer_ctx = CollectWriter.init(&partial_line, allocator);
+                const streamed = reader.streamDelimiterEnding(&writer_ctx.base, '\n') catch |err| {
+                    logSessionWarning(file_path, "error while reading claude session stream", err);
+                    return;
+                };
+
+                var newline_consumed = true;
+                const discard_result = reader.discardDelimiterInclusive('\n') catch |err| switch (err) {
+                    error.EndOfStream => blk: {
+                        newline_consumed = false;
+                        break :blk 0;
+                    },
+                    else => {
+                        logSessionWarning(file_path, "error while advancing claude session stream", err);
+                        return;
+                    },
+                };
+
+                if (streamed == 0 and partial_line.items.len == 0 and !newline_consumed) {
+                    break;
+                }
+
+                streamed_total += streamed;
+                if (streamed_total > max_session_size) return;
+
+                const trimmed = std.mem.trim(u8, partial_line.items, " \t\r\n");
+                if (trimmed.len != 0) {
+                    line_index += 1;
+                    try handleClaudeLine(
+                        allocator,
+                        arena,
+                        trimmed,
+                        line_index,
+                        file_path,
+                        &seen_messages,
+                        &session_label,
+                        &session_label_overridden,
+                        events,
+                        &current_model,
+                        &current_model_is_fallback,
+                    );
+                }
+
+                if (!newline_consumed) break;
+                streamed_total += discard_result;
+                if (streamed_total > max_session_size) return;
+            }
+        }
+
+        fn handleClaudeLine(
+            allocator: std.mem.Allocator,
+            arena: std.mem.Allocator,
+            line: []const u8,
+            line_index: usize,
+            file_path: []const u8,
+            seen_messages: *std.AutoHashMap(u64, void),
+            session_label: *[]const u8,
+            session_label_overridden: *bool,
+            events: *std.ArrayListUnmanaged(Model.TokenUsageEvent),
+            current_model: *?[]const u8,
+            current_model_is_fallback: *bool,
+        ) !void {
+            var parsed_doc = std.json.parseFromSlice(std.json.Value, allocator, line, .{}) catch |err| {
+                std.log.warn(
+                    "{s}: failed to parse claude session file '{s}' line {d} ({s})",
+                    .{ provider_name, file_path, line_index, @errorName(err) },
+                );
+                return;
+            };
+            defer parsed_doc.deinit();
+
+            const record = switch (parsed_doc.value) {
+                .object => |obj| obj,
+                else => return,
+            };
+
+            if (!session_label_overridden.*) {
+                if (record.get("sessionId")) |sid_value| {
+                    switch (sid_value) {
+                        .string => |slice| {
+                            const duplicate = duplicateNonEmpty(arena, slice) catch null;
+                            if (duplicate) |dup| {
+                                session_label.* = dup;
+                                session_label_overridden.* = true;
+                            }
+                        },
+                        else => {},
+                    }
+                }
+            }
+
+            try emitClaudeEvent(
+                allocator,
+                arena,
+                record,
+                seen_messages,
+                session_label.*,
+                events,
+                current_model,
+                current_model_is_fallback,
+            );
+        }
+
+        fn emitClaudeEvent(
+            allocator: std.mem.Allocator,
+            arena: std.mem.Allocator,
+            record: std.json.ObjectMap,
+            seen_messages: *std.AutoHashMap(u64, void),
+            session_label: []const u8,
+            events: *std.ArrayListUnmanaged(Model.TokenUsageEvent),
+            current_model: *?[]const u8,
+            current_model_is_fallback: *bool,
+        ) !void {
+            const type_value = record.get("type") orelse return;
+            const type_slice = switch (type_value) {
+                .string => |slice| slice,
+                else => return,
+            };
+            if (!std.mem.eql(u8, type_slice, "assistant")) return;
+
+            const message_value = record.get("message") orelse return;
+            const message_obj = switch (message_value) {
+                .object => |obj| obj,
+                else => return,
+            };
+
+            if (!try shouldEmitClaudeMessage(session_label, seen_messages, message_obj)) {
+                return;
+            }
+
+            const usage_value = message_obj.get("usage") orelse return;
+            const usage_obj = switch (usage_value) {
+                .object => |obj| obj,
+                else => return,
+            };
+
+            const timestamp_value = record.get("timestamp") orelse return;
+            const timestamp_slice = switch (timestamp_value) {
+                .string => |slice| slice,
+                else => return,
+            };
+            const timestamp_copy = duplicateNonEmpty(arena, timestamp_slice) catch return;
+            const owned_timestamp = timestamp_copy orelse return;
+            const iso_date = timeutil.localIsoDateFromTimestamp(owned_timestamp) catch {
+                return;
+            };
+
+            var extracted_model: ?[]const u8 = null;
+            if (message_obj.get("model")) |model_value| {
+                switch (model_value) {
+                    .string => |slice| {
+                        const duplicated = duplicateNonEmpty(arena, slice) catch null;
+                        if (duplicated) |dup| {
+                            extracted_model = dup;
+                        }
+                    },
+                    else => {},
+                }
+            }
+
+            var model_name = extracted_model;
+            var is_fallback = false;
+            if (model_name) |named| {
+                current_model.* = named;
+                current_model_is_fallback.* = false;
+            } else if (current_model.*) |known| {
+                model_name = known;
+                is_fallback = current_model_is_fallback.*;
+            } else if (LEGACY_FALLBACK_MODEL) |legacy| {
+                model_name = legacy;
+                is_fallback = true;
+                current_model.* = model_name;
+                current_model_is_fallback.* = true;
+            } else {
+                return;
+            }
+
+            const raw = parseClaudeUsage(usage_obj);
+            const usage = Model.TokenUsage.fromRaw(raw);
+            if (usage.input_tokens == 0 and usage.cached_input_tokens == 0 and usage.output_tokens == 0 and usage.reasoning_output_tokens == 0) {
+                return;
+            }
+
+            if (LEGACY_FALLBACK_MODEL) |legacy| {
+                if (std.mem.eql(u8, model_name.?, legacy) and extracted_model == null) {
+                    is_fallback = true;
+                    current_model_is_fallback.* = true;
+                }
+            }
+
+            const event = Model.TokenUsageEvent{
+                .session_id = session_label,
+                .timestamp = owned_timestamp,
+                .local_iso_date = iso_date,
+                .model = model_name.?,
+                .usage = usage,
+                .is_fallback = is_fallback,
+            };
+            try events.append(allocator, event);
+        }
+
+        fn shouldEmitClaudeMessage(
+            session_label: []const u8,
+            seen_messages: *std.AutoHashMap(u64, void),
+            message_obj: std.json.ObjectMap,
+        ) !bool {
+            const id_value = message_obj.get("id") orelse return true;
+            const id_slice = switch (id_value) {
+                .string => |slice| slice,
+                else => return true,
+            };
+            const session_hash = std.hash.Wyhash.hash(0, session_label);
+            const msg_hash = std.hash.Wyhash.hash(session_hash, id_slice);
+            const gop = try seen_messages.getOrPut(msg_hash);
+            return !gop.found_existing;
+        }
+
+        fn parseClaudeUsage(usage_obj: std.json.ObjectMap) RawUsage {
+            const direct_input = jsonValueToU64(usage_obj.get("input_tokens"));
+            const cache_creation = jsonValueToU64(usage_obj.get("cache_creation_input_tokens"));
+            const cached_reads = jsonValueToU64(usage_obj.get("cache_read_input_tokens"));
+            const output_tokens = jsonValueToU64(usage_obj.get("output_tokens"));
+
+            const input_total = std.math.add(u64, direct_input, cache_creation) catch std.math.maxInt(u64);
+            const with_cached = std.math.add(u64, input_total, cached_reads) catch std.math.maxInt(u64);
+            const total_tokens = std.math.add(u64, with_cached, output_tokens) catch std.math.maxInt(u64);
+
+            return .{
+                .input_tokens = direct_input,
+                .cache_creation_input_tokens = cache_creation,
+                .cached_input_tokens = cached_reads,
+                .output_tokens = output_tokens,
+                .reasoning_output_tokens = 0,
+                .total_tokens = total_tokens,
             };
         }
 
@@ -1176,6 +1451,7 @@ pub fn Provider(comptime cfg: ProviderConfig) type {
                 }
 
                 var input_rate: ?f64 = null;
+                var cache_creation_rate: ?f64 = null;
                 var cached_rate: ?f64 = null;
                 var output_rate: ?f64 = null;
 
@@ -1191,6 +1467,8 @@ pub fn Provider(comptime cfg: ProviderConfig) type {
                                 input_rate = try readNumber(reader, scratch);
                             } else if (std.mem.eql(u8, field, "output_cost_per_token")) {
                                 output_rate = try readNumber(reader, scratch);
+                            } else if (std.mem.eql(u8, field, "cache_creation_input_token_cost")) {
+                                cache_creation_rate = try readNumber(reader, scratch);
                             } else if (std.mem.eql(u8, field, "cache_read_input_token_cost")) {
                                 cached_rate = try readNumber(reader, scratch);
                             } else {
@@ -1202,9 +1480,11 @@ pub fn Provider(comptime cfg: ProviderConfig) type {
                 }
 
                 if (input_rate == null or output_rate == null) return null;
+                const creation = cache_creation_rate orelse input_rate.?;
                 const cached = cached_rate orelse input_rate.?;
                 return Model.ModelPricing{
                     .input_cost_per_m = input_rate.? * Model.MILLION,
+                    .cache_creation_cost_per_m = creation * Model.MILLION,
                     .cached_input_cost_per_m = cached * Model.MILLION,
                     .output_cost_per_m = output_rate.? * Model.MILLION,
                 };

--- a/src/render.zig
+++ b/src/render.zig
@@ -100,6 +100,8 @@ pub const Renderer = struct {
     fn writeUsageFields(jw: anytype, usage: Model.TokenUsage) !void {
         try jw.objectField("input_tokens");
         try jw.write(usage.input_tokens);
+        try jw.objectField("cache_creation_input_tokens");
+        try jw.write(usage.cache_creation_input_tokens);
         try jw.objectField("cached_input_tokens");
         try jw.write(usage.cached_input_tokens);
         try jw.objectField("output_tokens");

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Model = @import("model.zig");
+const claude = @import("providers/claude.zig");
 const codex = @import("providers/codex.zig");
 const gemini = @import("providers/gemini.zig");
 const render = @import("render.zig");
@@ -32,6 +33,7 @@ pub const ProviderSpec = struct {
 };
 
 pub const providers = [_]ProviderSpec{
+    .{ .name = "claude", .phase_label = "collect_claude", .collect = claude.collect },
     .{ .name = "codex", .phase_label = "collect_codex", .collect = codex.collect },
     .{ .name = "gemini", .phase_label = "collect_gemini", .collect = gemini.collect },
 };


### PR DESCRIPTION
Implements the Claude session provider, including parsing of its JSONL log format and updating the core token usage model to track cache creation input tokens and associated pricing.