### PR TITLE
test: verify token usage parsing for all providers

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -43,4 +43,15 @@ pub fn build(b: *std.Build) void {
     if (b.args) |args| {
         run_cmd.addArgs(args);
     }
+
+    const test_module = b.createModule(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const unit_tests = b.addTest(.{ .root_module = test_module });
+    unit_tests.root_module.link_libc = true;
+    const test_step = b.step("test", "Run unit tests");
+    const test_cmd = b.addRunArtifact(unit_tests);
+    test_step.dependOn(&test_cmd.step);
 }

--- a/fixtures/claude/basic.jsonl
+++ b/fixtures/claude/basic.jsonl
@@ -1,0 +1,1 @@
+{"sessionId":"claude-session","type":"assistant","timestamp":"2025-10-28T09:31:23.624Z","requestId":"req_fixture","message":{"id":"msg_fixture","model":"claude-3-5-sonnet","usage":{"input_tokens":1500,"cache_creation_input_tokens":100,"cache_read_input_tokens":250,"output_tokens":600}}}

--- a/fixtures/codex/basic.jsonl
+++ b/fixtures/codex/basic.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2025-09-25T14:25:27.897Z","type":"turn_context","payload":{"model":"gpt-5-codex"}}
+{"timestamp":"2025-09-25T14:26:00.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1200,"cached_input_tokens":200,"output_tokens":50,"reasoning_output_tokens":0,"total_tokens":1450}}}}

--- a/fixtures/gemini/basic.json
+++ b/fixtures/gemini/basic.json
@@ -1,0 +1,18 @@
+{
+  "sessionId": "gem-session",
+  "messages": [
+    {
+      "id": "msg-1",
+      "timestamp": "2025-10-26T15:09:39.226Z",
+      "model": "gemini-1.5-pro",
+      "tokens": {
+        "input": 4000,
+        "cached": 500,
+        "output": 120,
+        "tool": 5,
+        "thoughts": 20,
+        "total": 4645
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds unit tests and fixtures for Codex, Gemini, and Claude session file parsing. Also enables the 'test' step in build.zig.