### PR TITLE
refactor(session): pre-scan directory and use indices for worker tasks

### DIFF
--- a/src/providers/session_provider.zig
+++ b/src/providers/session_provider.zig
@@ -220,7 +220,12 @@ pub fn Provider(comptime cfg: ProviderConfig) type {
                     defer local_events.deinit(worker_allocator);
 
                     const relative = shared.paths[args.index];
-                    const absolute_path = std.fs.path.join(worker_allocator, &.{ shared.sessions_dir, relative }) catch {
+                    const absolute_path = std.fs.path.join(worker_allocator, &.{ shared.sessions_dir, relative }) catch |err| {
+                        std.log.warn("{s}.collectEvents: unable to build path for '{s}' ({s})", .{
+                            provider_name,
+                            relative,
+                            @errorName(err),
+                        });
                         return;
                     };
                     defer worker_allocator.free(absolute_path);


### PR DESCRIPTION
Collects all session file paths before spawning worker tasks, allowing for accurate progress estimation and simplifying worker arguments.