### PR TITLE
feat(session_provider): support date suffix model aliases

### DIFF
--- a/src/providers/session_provider.zig
+++ b/src/providers/session_provider.zig
@@ -252,7 +252,7 @@ const JsonTokenSlice = union(enum) {
             .borrowed => {},
             .owned => |buf| allocator.free(buf),
         }
-        self.* = JsonTokenSlice{ .borrowed = &.{} };
+        self.* = JsonTokenSlice{ .borrowed = "" };
     }
 
     fn fromString(allocator: std.mem.Allocator, reader: *std.json.Reader) !JsonTokenSlice {


### PR DESCRIPTION
Model names containing @YYYYMMDD suffixes are now aliased to model-YYYYMMDD.

Refactors buffer handling to use unmanaged ArrayLists and explicit allocators in parsing functions.