### PR TITLE
refactor(gemini): process model and timestamp during field parsing

### DIFF
--- a/src/providers/gemini.zig
+++ b/src/providers/gemini.zig
@@ -280,6 +280,7 @@ fn emitGeminiMessage(context: *GeminiMessageContext) !void {
         .display_input_tokens = context.state.ctx.computeDisplayInput(delta),
     };
     try context.state.events.append(context.state.allocator, event);
+    // Transfer timestamp ownership to the appended event to avoid double-free.
     context.timestamp = null;
 }
 


### PR DESCRIPTION
Moves model capture and timestamp conversion logic from `emitGeminiMessage` to `parseGeminiMessageField`. This simplifies emission and improves resource management within the message context.