### PR TITLE
refactor(provider): use std.Io.Group for concurrent event collection

### DIFF
--- a/src/providers/provider.zig
+++ b/src/providers/provider.zig
@@ -1270,7 +1270,6 @@ pub fn Provider(comptime cfg: ProviderConfig) type {
                             });
                             continue;
                         };
-                        defer worker_allocator.free(absolute_path);
 
                         if (relative.len <= json_ext.len or !std.mem.endsWith(u8, relative, json_ext)) continue;
                         const session_id_slice = relative[0 .. relative.len - json_ext.len];


### PR DESCRIPTION
Migrates event collection workers from manual thread spawning to using `std.Io.Threaded` and `std.Io.Group` for structured concurrency.