### PR TITLE
feat(cli): introduce --recursive flag and implement for crush

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The output is a table or JSON, suitable for dashboards.
 - [Amp](https://ampcode.com/)
 - [Claude Code](https://www.claude.com/product/claude-code)
 - [Codex CLI](https://developers.openai.com/codex/cli/)
-- [Crush](https://github.com/charmbracelet/crush): project-based, recursively crawled
+- [Crush](https://github.com/charmbracelet/crush): project-based (supports recursive crawling with `-r`)
 - [Gemini CLI](https://geminicli.com/)
 - [Opencode](https://opencode.ai/)
 - [Zed](https://zed.dev/)
@@ -49,6 +49,11 @@ tokenuze --agent claude --agent codex
 And combine everything
 ```
 tokenuze --agent claude --agent codex --since 20250101 --until 20250107
+```
+
+Use the `-r` or `--recursive` flag to enable recursive searching (supported by providers like Crush):
+```bash
+tokenuze --agent crush --recursive
 ```
 
 By appending the `--sessions` flag you can display session usage instead of daily.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -37,6 +37,7 @@ const OptionId = enum {
     version,
     help,
     list_agents,
+    recursive,
 };
 
 const OptionArgKind = enum {
@@ -66,6 +67,7 @@ const option_specs = [_]OptionSpec{
     .{ .id = .upload, .long_name = "upload", .desc = "Upload Tokenuze JSON via DASHBOARD_API_KEY and DASHBOARD_API_URL envs" },
     .{ .id = .machine_id, .long_name = "machine-id", .desc = "Print the machine id and exit" },
     .{ .id = .list_agents, .long_name = "list-agents", .desc = "List supported agents and their usage paths" },
+    .{ .id = .recursive, .long_name = "recursive", .short_name = 'r', .desc = "Recursively search for data files (supported by some providers)" },
     .{ .id = .version, .long_name = "version", .desc = "Print version number and exit" },
     .{ .id = .help, .long_name = "help", .short_name = 'h', .desc = "Show this message and exit" },
 };
@@ -184,7 +186,6 @@ pub fn printVersion(io: std.Io, version: []const u8) !void {
     try writer.print("{s}\n", .{version});
     writer.flush() catch |err| switch (err) {
         error.WriteFailed => {},
-        else => return err,
     };
 }
 
@@ -204,7 +205,6 @@ pub fn printAgentList(ctx: tokenuze.Context) !void {
     }
     writer.flush() catch |err| switch (err) {
         error.WriteFailed => {},
-        else => return err,
     };
 }
 
@@ -275,6 +275,7 @@ fn applyOption(
             options.output_explicit = true;
         },
         .list_agents => options.list_agents = true,
+        .recursive => options.filters.recursive = true,
         .log_level => {
             const value = args.next() orelse return missingValueError(spec.long_name);
             options.log_level = try parseLogLevelArg(value);

--- a/src/main.zig
+++ b/src/main.zig
@@ -108,7 +108,6 @@ fn printMachineId(ctx: tokenuze.Context) !void {
     try writer.print("{s}\n", .{id[0..]});
     writer.flush() catch |err| switch (err) {
         error.WriteFailed => {},
-        else => return err,
     };
 }
 
@@ -133,6 +132,5 @@ fn handleSessionsOutput(ctx: tokenuze.Context, options: cli.CliOptions) !void {
     }
     writer.flush() catch |err| switch (err) {
         error.WriteFailed => {},
-        else => return err,
     };
 }

--- a/src/model.zig
+++ b/src/model.zig
@@ -22,6 +22,7 @@ pub const DateFilters = struct {
     pretty_output: bool = false,
     output_format: OutputFormat = .table,
     timezone_offset_minutes: i16 = @intCast(timeutil.default_timezone_offset_minutes),
+    recursive: bool = false,
 };
 
 pub const ParseDateError = error{

--- a/src/providers/crush.zig
+++ b/src/providers/crush.zig
@@ -44,7 +44,7 @@ pub fn streamEvents(
     consumer: provider.EventConsumer,
     progress: ?std.Progress.Node,
 ) !void {
-    var db_paths = try findCrushDbPaths(ctx);
+    var db_paths = try findCrushDbPaths(ctx, filters.recursive);
     defer {
         for (db_paths.items) |p| ctx.allocator.free(p);
         db_paths.deinit(ctx.allocator);
@@ -132,7 +132,7 @@ fn processDb(ctx: Context, filters: model.DateFilters, consumer: provider.EventC
     };
 }
 
-fn findCrushDbPaths(ctx: Context) !std.ArrayList([]u8) {
+fn findCrushDbPaths(ctx: Context, recursive: bool) !std.ArrayList([]u8) {
     const allocator = ctx.allocator;
     const temp_allocator = ctx.temp_allocator;
     const io = ctx.io;
@@ -163,6 +163,7 @@ fn findCrushDbPaths(ctx: Context) !std.ArrayList([]u8) {
             } orelse break;
 
             if (entry.kind == .directory) {
+                if (!recursive) continue;
                 if (std.mem.eql(u8, entry.name, ".") or std.mem.eql(u8, entry.name, "..")) continue;
                 const child = std.fs.path.join(temp_allocator, &.{ dir_path, entry.name }) catch |err| {
                     std.log.debug("crush: join failed for {s}/{s} ({s})", .{ dir_path, entry.name, @errorName(err) });

--- a/src/root.zig
+++ b/src/root.zig
@@ -479,7 +479,6 @@ fn progressHandle(node: std.Progress.Node) ?std.Progress.Node {
 fn flushOutput(writer: anytype) !void {
     writer.flush() catch |err| switch (err) {
         error.WriteFailed => {},
-        else => return err,
     };
 }
 


### PR DESCRIPTION
Adds the `--recursive` (-r) flag to enable deep directory scanning for supported providers.

The flag is implemented in the CLI and model filters, and the Crush provider logic is updated to respect this setting when searching for database paths. Also removes redundant error handling boilerplate in output functions.